### PR TITLE
Fix TypeError

### DIFF
--- a/octoprint_taposmartplug/__init__.py
+++ b/octoprint_taposmartplug/__init__.py
@@ -409,7 +409,8 @@ class taposmartplugPlugin(octoprint.plugin.SettingsPlugin,
 			p100.login() #Sends credentials to the plug and creates AES Key and IV for further methods
 			response = p100.getDeviceInfo() #Returns dict with all the device info
 
-			chk = self.lookup(json.loads(response), *["result", "device_on"])
+			self._taposmartplug_logger.debug(response)
+			chk = self.lookup(response, *["result", "device_on"])
 
 			self._taposmartplug_logger.debug(chk)
 


### PR DESCRIPTION
This is fix for `TypeError: the JSON object must be str, bytes or bytearray, not dict`
The current version of fishbigger/TapoP100 returns dict, not json string.